### PR TITLE
Added SwiftPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,12 @@ Carthage
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
 # Pods/
+
+# Swift Package Manager
+.build
+Packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ script:
 
   - xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator -destination 'name=iPhone 6,OS=10.0' ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test | xcpretty
 
+  - swift build
+
   - pod _1.1.0.rc2_ lib lint

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "KZFileWatchers"
+)

--- a/README.md
+++ b/README.md
@@ -20,14 +20,32 @@ This framework provides:
 
 ## Installation
 
-KZFileWatchers is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+KZFileWatchers is available through [CocoaPods](http://cocoapods.org) and [Swift Package Manager](http://github.com/apple/swift-package-manager).
+
+### CocoaPods
+
+In order to install KZFileWatchers by using CocoaPods, simply add the following line to your Podfile:
 
 ```ruby
 pod "KZFileWatchers"
 ```
 
 Last version to support Swift 2.3 is `0.1.2`
+
+### Swift Package Manager
+
+Installing KZFileWatchers over SwiftPM is only supported since version 1.0.1. You just need to add it as a dependency to your Package.swift manifest:
+
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "YourTarget",
+    dependencies: [
+        .Package(url: "https://github.com/krzysztofzablocki/KZFileWatchers.git", majorVersion: 1),
+    ]
+)
+```
 
 ## Author
 

--- a/Sources/KZFileWatchers
+++ b/Sources/KZFileWatchers
@@ -1,0 +1,1 @@
+../KZFileWatchers/Classes/


### PR DESCRIPTION
Adding SwiftPM support for https://github.com/krzysztofzablocki/Sourcery/issues/28 requires KZFileWatchers to support it too.

If you want, I can add SwiftPM as additional installation method to your `README.md`.
As SwiftPM currently doesn't support iOS, shall I just add `swift build` to `.travis.yml`? This would at least ensure, that the `Package.swift` file format is correct.

In order to finish support for SwiftPM, you need to schedule a new release and tag.