### PR TITLE
fix: detect changes made by vim

### DIFF
--- a/KZFileWatchers/Classes/Local/Local.swift
+++ b/KZFileWatchers/Classes/Local/Local.swift
@@ -96,7 +96,13 @@ public extension FileWatcher {
                 
                 if flags.contains(.delete) || flags.contains(.rename) {
                     _ = try? self.stop()
-                    _ = try? self.startObserving(closure)
+                    do {
+                        try self.startObserving(closure)
+                    } catch {
+                        self.queue.asyncAfter(deadline: .now() + self.refreshInterval) {
+                            _ = try? self.startObserving(closure)
+                        }
+                    }
                     return
                 }
                 


### PR DESCRIPTION
After the change made to fix #2, changes made by vim and MacVim aren't detected. This fix is arguably hack-ish — it involves a one-time retry with a delay when we can't find the file to restart observing —, but given how vim seems to do this strange thing where saving a file seems to be delete it and then created the replacement with the same filename..

Note that with this retry, there's this strange behaviour (supposedly due to how vim works):

1. Save file in MacVim
2. Changes get detected, this can continue to work a few times
...
3. Save file in MacVim
4. Can't find file to restart restart observing
5. Retry once, look for the file to restart observing
6. Changes gets detected correctly

There's a strange pause of a few seconds between 5-6. If you switch away from vim (if in Terminal) or in MacVim.app, it resumes immediately.

I'd be happy if there's a better way to make this work for vim/MacVim though :)